### PR TITLE
Fix issue with making Tar archive on Windows and Untarring on Linux

### DIFF
--- a/tarinator.go
+++ b/tarinator.go
@@ -1,148 +1,148 @@
 package tarinator
 
-import(
-    "archive/tar"
-    "os"
-    "io"
-    "log"
-    "path/filepath"
-    "strings"
-    "compress/gzip"
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 func Tarinate(paths []string, tarPath string) error {
-    file, err := os.Create(tarPath)
-    if err != nil {
-        return err
-    }
+	file, err := os.Create(tarPath)
+	if err != nil {
+		return err
+	}
 
-    defer file.Close()
+	defer file.Close()
 
-    var fileReader io.WriteCloser = file
+	var fileReader io.WriteCloser = file
 
-    if strings.HasSuffix(tarPath, ".gz") {
-        fileReader = gzip.NewWriter(file)
+	if strings.HasSuffix(tarPath, ".gz") {
+		fileReader = gzip.NewWriter(file)
 
-        defer fileReader.Close()
-    }
+		defer fileReader.Close()
+	}
 
-    tw := tar.NewWriter(fileReader)
-    defer tw.Close()
+	tw := tar.NewWriter(fileReader)
+	defer tw.Close()
 
-    for _,i := range paths {
-        if err := tarwalk(i, "", tw); err != nil {
-            return err
-        }
-    }
+	for _, i := range paths {
+		if err := tarwalk(i, "", tw); err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func tarwalk(source, target string, tw *tar.Writer) error {
-    info, err := os.Stat(source)
-    if err != nil {
-        return nil
-    }
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil
+	}
 
-    var baseDir string
-    if info.IsDir() {
-        baseDir = filepath.Base(source)
-    }
+	var baseDir string
+	if info.IsDir() {
+		baseDir = filepath.Base(source)
+	}
 
-    return filepath.Walk(source,
-        func(path string, info os.FileInfo, err error) error {
-            if err != nil {
-                return err
-            }
-            header, err := tar.FileInfoHeader(info, info.Name())
-            if err != nil {
-                return err
-            }
+	return filepath.Walk(source,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			header, err := tar.FileInfoHeader(info, info.Name())
+			if err != nil {
+				return err
+			}
 
-            if baseDir != "" {
-                header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
-            }
+			if baseDir != "" {
+				header.Name = (filepath.Join(baseDir, strings.TrimPrefix(path, source)))
+			}
 
-            if err := tw.WriteHeader(header); err != nil {
-                return err
-            }
+			if err := tw.WriteHeader(header); err != nil {
+				return err
+			}
 
-            if info.IsDir() {
-                return nil
-            }
+			if info.IsDir() {
+				return nil
+			}
 
-            if !info.Mode().IsRegular() {
-                return nil
-            }
+			if !info.Mode().IsRegular() {
+				return nil
+			}
 
-            file, err := os.Open(path)
-            if err != nil {
-                return err
-            }
-            defer file.Close()
-            _, err = io.Copy(tw, file)
-            return err
-        })
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(tw, file)
+			return err
+		})
 }
 
 func UnTarinate(extractPath, sourcefile string) error {
-    file, err := os.Open(sourcefile)
+	file, err := os.Open(sourcefile)
 
-    if err != nil {
-        return err
-    }
+	if err != nil {
+		return err
+	}
 
-    defer file.Close()
+	defer file.Close()
 
-    var fileReader io.ReadCloser = file
+	var fileReader io.ReadCloser = file
 
-    if strings.HasSuffix(sourcefile, ".gz") {
-        if fileReader, err = gzip.NewReader(file); err != nil {
-            return err
-        }
-        defer fileReader.Close()
-    }
+	if strings.HasSuffix(sourcefile, ".gz") {
+		if fileReader, err = gzip.NewReader(file); err != nil {
+			return err
+		}
+		defer fileReader.Close()
+	}
 
-    tarBallReader := tar.NewReader(fileReader)
+	tarBallReader := tar.NewReader(fileReader)
 
-    for {
-        header, err := tarBallReader.Next()
-        if err != nil {
-            if err == io.EOF {
-                break
-            }
-            return err
-        }
+	for {
+		header, err := tarBallReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
 
-        filename := filepath.Join(extractPath, header.Name)
+		filename := filepath.Join(extractPath, (header.Name))
 
-        switch header.Typeflag {
-        case tar.TypeDir:
-            err = os.MkdirAll(filename, os.FileMode(header.Mode)) // or use 0755 if you prefer
+		switch header.Typeflag {
+		case tar.TypeDir:
+			err = os.MkdirAll(filename, os.FileMode(header.Mode)) // or use 0755 if you prefer
 
-            if err != nil {
-                return err
-            }
+			if err != nil {
+				return err
+			}
 
-        case tar.TypeReg:
-            writer, err := os.Create(filename)
+		case tar.TypeReg:
+			writer, err := os.Create(filename)
 
-            if err != nil {
-                return err
-            }
+			if err != nil {
+				return err
+			}
 
-            io.Copy(writer, tarBallReader)
+			io.Copy(writer, tarBallReader)
 
-            err = os.Chmod(filename, os.FileMode(header.Mode))
+			err = os.Chmod(filename, os.FileMode(header.Mode))
 
-            if err != nil {
-                return err
-            }
+			if err != nil {
+				return err
+			}
 
-            writer.Close()
-        default:
-            log.Printf("Unable to untar type: %c in file %s", header.Typeflag, filename)
-        }
-    }
-    return nil
+			writer.Close()
+		default:
+			log.Printf("Unable to untar type: %c in file %s", header.Typeflag, filename)
+		}
+	}
+	return nil
 }

--- a/tarinator.go
+++ b/tarinator.go
@@ -60,7 +60,7 @@ func tarwalk(source, target string, tw *tar.Writer) error {
 			}
 
 			if baseDir != "" {
-				header.Name = (filepath.Join(baseDir, strings.TrimPrefix(path, source)))
+				header.Name = filepath.ToSlash(filepath.Join(baseDir, strings.TrimPrefix(path, source)))
 			}
 
 			if err := tw.WriteHeader(header); err != nil {
@@ -114,7 +114,7 @@ func UnTarinate(extractPath, sourcefile string) error {
 			return err
 		}
 
-		filename := filepath.Join(extractPath, (header.Name))
+		filename := filepath.Join(extractPath, filepath.FromSlash(header.Name))
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/tarinator_test.go
+++ b/tarinator_test.go
@@ -1,37 +1,57 @@
 package tarinator
 
-import(
-    "testing"
-    "os"
+import (
+	"io/ioutil"
+	"os"
+	"testing"
 )
 
-func TestTarGzFromFiles(t *testing.T) {
-    paths := []string{
-        "somescript.sh",
-        "test_files/",
-    }
+func TestArchive(t *testing.T) {
+	paths := []string{
+		"somescript.sh",
+		"test_files/",
+	}
 
-    err := Tarinate(paths, "output_test.tar.gz")
-    if err != nil {
-        t.Errorf("Failed: %s\n", err)
-        return
-    }
+	err := Tarinate(paths, "output_test.tar.gz")
+	if err != nil {
+		t.Errorf("Failed: %s\n", err)
+		return
+	}
 }
 
-func TestUnTarGzFromFiles(t *testing.T) {
-    if _, err := os.Stat("output_test.tar.gz"); os.IsNotExist(err) {
-        t.Error("No file for untaring dected")
-        return
-    }
+func TestOpen(t *testing.T) {
+	if _, err := os.Stat("output_test.tar.gz"); os.IsNotExist(err) {
+		t.Error("No file for untaring dected")
+		return
+	}
+	err := os.Mkdir("testing", 0755)
+	if err != nil {
+		os.RemoveAll("testing")
+		os.Mkdir("testing", 0755)
+	}
 
-    err := UnTarinate("/tmp", "output_test.tar.gz")
-    if err != nil {
-        t.Errorf("Failed untaring: %s\n", err)
-        return
-    }
+	err = UnTarinate("testing", "output_test.tar.gz")
+	if err != nil {
+		t.Errorf("Failed untaring: %s\n", err)
+		return
+	}
+
+	files, err := ioutil.ReadDir("testing")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(files) != 2 {
+		t.Errorf("The directory wasn't actually written")
+	}
 }
 
+func isDir(pth string) (bool, error) {
+	fi, err := os.Stat(pth)
+	if err != nil {
+		return false, err
+	}
 
-
-
-
+	return fi.IsDir(), nil
+}


### PR DESCRIPTION
Hi @verybluebot! A contributor helped me with *[croc](https://github.com/schollz/croc)* and used your package. Thanks a lot for this, it has saved us a lot of time!

However, I did notice an issue that came up when I made an archive on Windows. If I made the archive on Windows, and then opened the archive in Linux, the contents of a tarred directory would be written instead as individual files with the path as the filename. The fix is very easy - just use `FromSlash` and `ToSlash` with the filenames.

Here's a rundown of the checks I made. I made d12b464d8ed4dd294ca596bf09b2afd79efd1a68 to better check the issue and I made 835680f17d252bd7a6047e670079f35e5626dc1e to fix the issue.

# Illustrating the issue

On Windows computer:

```
$ go get github.com/schollz/tarinator-go
$ cd $GOPATH/src/github.com/schollz/tarinator-go
$ git checkout d12b464d8ed4dd294ca596bf09b2afd79efd1a68
$ go test
$ scp output_test.tar.gz user@some-linux-computer:
```

On some-linux-computer:
```
$ go get github.com/schollz/tarinator-go
$ cd $GOPATH/src/github.com/schollz/tarinator-go
$ git checkout d12b464d8ed4dd294ca596bf09b2afd79efd1a68
$ mv ~/output_test.tar.gz .
$ go test -run=Open
--- FAIL: TestOpen (0.00s)
        tarinator_test.go:46: The directory wasn't actually written
FAIL
exit status 1
FAIL    github.com/schollz/tarinator-go 0.004s
$ ls -l testing
total 20
-rw-rw-rw- 1 zns zns   56 Nov  4 03:49 somescript.sh
drwxrwxr-x 2 zns zns 4096 Nov  4 03:49 test_files
drwxrwxr-x 2 zns zns 4096 Nov  4 03:49 test_files\test_files\bla
-rw-rw-rw- 1 zns zns    4 Nov  4 03:49 test_files\test_files\bla\bla
-rw-rw-rw- 1 zns zns  583 Nov  4 03:49 test_files\test_files\somedata.json
```

As you can see, there are 5 things in the `testing/` directory when there should only be 2 (`test_files` and `somescript.sh`).

# Now, the fix. 

On Windows computer

```
$ git checkout master
$ go test
$ scp output_test.tar.gz user@some-linux-computer:
```

And then back to Linux computer:

```
$ mv ~/output_test.tar.gz .
$ git checkout master
$ go test -run=Open
PASS
ok      github.com/schollz/tarinator-go 0.004s
$ ls -l testing
total 8
-rw-rw-rw- 1 zns zns   56 Nov  4 03:52 somescript.sh
drwxrwxr-x 3 zns zns 4096 Nov  4 03:52 test_files
```

Now it behaves as expected.
